### PR TITLE
added missing #include <limits>

### DIFF
--- a/include/tudocomp/ds/uint_t.hpp
+++ b/include/tudocomp/ds/uint_t.hpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <cmath>
 #include <sstream>
+#include <limits>
 
 namespace tdc {
 


### PR DESCRIPTION
I am getting compile errors hinting at a missing `#include <limits>`

```
/home/dominik-drexler/projects/code/tree-compression/dependencies/build/compact_sparse_hash/src/compact_sparse_hash/submodules/bit_span/include/tudocomp/ds/uint_t.hpp:198:11: error: ‘numeric_limits’ is not a class template
  198 |     class numeric_limits<tdc::uint_impl_t<N>> {
      |           ^~~~~~~~~~~~~~
/home/dominik-drexler/projects/code/tree-compression/dependencies/build/compact_sparse_hash/src/compact_sparse_hash/submodules/bit_span/include/tudocomp/ds/uint_t.hpp:208:31: error: ‘float_denorm_style’ in namespace ‘std’ does not name a type
  208 |         static constexpr std::float_denorm_style has_denorm = std::denorm_absent;
      |                          
 ```